### PR TITLE
chore: configure flutter_launcher_icons

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   carousel_slider: ^5.1.1
   flutter_typeahead: ^5.2.0
   shared_preferences: ^2.5.3
-  flutter_launcher_icons: ^0.14.4
   http: ^1.5.0
   provider: ^6.1.5
   dotted_border: ^3.1.0
@@ -31,10 +30,11 @@ dependencies:
 
 dev_dependencies:
   pedantic: ^1.11.1
+  flutter_launcher_icons: ^0.14.4
 
 
 
-flutter_icons:
+flutter_launcher_icons:
   image_path_android: "assets/icon.png"
   image_path_ios: "assets/icon.png"
   android: true


### PR DESCRIPTION
## Summary
- move flutter_launcher_icons to dev_dependencies and update config block

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter pub run flutter_launcher_icons` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2364957648332aabd377bf3369da9